### PR TITLE
Added mouse genome mm9

### DIFF
--- a/Genome.cpp
+++ b/Genome.cpp
@@ -67,6 +67,31 @@ Genome::Genome(string name) : n_chr_(0)
     cnames_[21] = Genome::canonicalChromName("22"); clens_[21] =  51304566;
     cnames_[22] =  Genome::canonicalChromName("X"); clens_[22] = 155270560;
     cnames_[23] =  Genome::canonicalChromName("Y"); clens_[23] =  59373566;
+  } else if (name == "mm9" || name == "mgscv37") {
+    gname_       = "MGSCv37";
+    other_gname_ = "mm9";
+    n_chr_      = 21;
+    cnames_[0]  = Genome::canonicalChromName("1");  clens_[0]  = 197195432;
+    cnames_[1]  = Genome::canonicalChromName("2");  clens_[1]  = 181748087;
+    cnames_[2]  = Genome::canonicalChromName("3");  clens_[2]  = 159599783;
+    cnames_[3]  = Genome::canonicalChromName("4");  clens_[3]  = 155630120;
+    cnames_[4]  = Genome::canonicalChromName("5");  clens_[4]  = 152537259;
+    cnames_[5]  = Genome::canonicalChromName("6");  clens_[5]  = 149517037;
+    cnames_[6]  = Genome::canonicalChromName("7");  clens_[6]  = 152524553;
+    cnames_[7]  = Genome::canonicalChromName("8");  clens_[7]  = 131738871;
+    cnames_[8]  = Genome::canonicalChromName("9");  clens_[8]  = 124076172;
+    cnames_[9]  = Genome::canonicalChromName("10"); clens_[9]  = 129993255;
+    cnames_[10] = Genome::canonicalChromName("11"); clens_[10] = 121843856;
+    cnames_[11] = Genome::canonicalChromName("12"); clens_[11] = 121257530;
+    cnames_[12] = Genome::canonicalChromName("13"); clens_[12] = 120284312;
+    cnames_[13] = Genome::canonicalChromName("14"); clens_[13] = 125194864;
+    cnames_[14] = Genome::canonicalChromName("15"); clens_[14] = 103494974;
+    cnames_[15] = Genome::canonicalChromName("16"); clens_[15] = 98319150;
+    cnames_[16] = Genome::canonicalChromName("17"); clens_[16] = 95272651;
+    cnames_[17] = Genome::canonicalChromName("18"); clens_[17] = 90772031;
+    cnames_[18] = Genome::canonicalChromName("19"); clens_[18] = 61342430;
+    cnames_[19] = Genome::canonicalChromName("X");  clens_[19] = 166650296;
+    cnames_[20] = Genome::canonicalChromName("Y");  clens_[20] = 15902555;
   } else {
     cerr<<"Unknown genome '"<<org_name<<"'."<<endl;
   }

--- a/cnvnator.cpp
+++ b/cnvnator.cpp
@@ -1,13 +1,13 @@
 // C/C++ includes
-#include <iostream> 
-#include <fstream> 
+#include <iostream>
+#include <fstream>
 
 #ifdef USE_YEPPP
 #include <yepMath.h>
 #include <yepLibrary.h>
 #endif
 
-using namespace std; 
+using namespace std;
 
 // Application includes
 #include "AliParser.hh"
@@ -46,7 +46,7 @@ int main(int argc,char *argv[])
   usage += argv[0];
   usage += " -pe   file1.bam ... -qual val(20) -over val(0.8) [-f file]\n";
   usage += "\n";
-  usage += "Valid genomes (-genome option) are: NCBI36, hg18, GRCh37, hg19\n";
+  usage += "Valid genomes (-genome option) are: NCBI36, hg18, GRCh37, hg19, mm9\n";
 
   if (argc < 2) {
     cerr<<"Not enough parameters."<<endl;
@@ -281,7 +281,7 @@ int main(int argc,char *argv[])
     }
     if (option == OPT_PE) { // pe
       HisMaker maker("null",genome);
-      if (call_file.length() > 0) 
+      if (call_file.length() > 0)
 	maker.pe_for_file(call_file,data_files,n_files,over,qual);
       else {
 	TApplication theApp("App",0,0);


### PR DESCRIPTION
With this patch, CNVnator can now be used with the mouse mm9 genome. I can add mm10 if you wish also.