### PR TITLE
Introduce CRAM file support

### DIFF
--- a/AliParser.cpp
+++ b/AliParser.cpp
@@ -16,7 +16,8 @@ AliParser::AliParser(string fileName,bool loadIndex) : sam(false),
   int len = fileName.length();
   if (len == 0) {
     stdin = true;
-  } else if (fileName.substr(len - 3,3) == "bam") {
+  } else if (fileName.substr(len - 3,3) == "bam" ||
+             fileName.substr(len - 4,4) == "cram") {
     //cout<<"Assuming BAM file for "<<fileName<<endl;
     file = samopen(fileName.c_str(),"rb",NULL);
     if (!file) cerr<<"Can't open file '"<<fileName<<"'."<<endl;

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION	       = v0.3.2
+VERSION	       = v0.3.3
 override LIBS += -lz
 
 ifneq ($(wildcard $(ROOTSYS)/lib/root),)


### PR DESCRIPTION
This is a quick and cheap fix to introduce CRAM support for CNVnator.

This addresses github issue #33 .

This change leverages the existing BAM parsing logic to also account for CRAM files.  Both [htslib][0] and [samtools][1] have unified APIs for accessing common file formats, such as SAM, BAM, and CRAM.

A more through approach to handling SAM, BAM, and CRAM files would be to convert the legacy `samopen`, `samclose`, and `bam_index_load` functions used in `AliParser.cpp` to respectively using the more modern `hopen/hts_open`, `hclose/hts_close`, and `sam_index_load` functions that are described in htslib and samtools versions 1.3.1 (and greater).  

The through approach would involve a bigger refactoring of the AliParser class and may take more time to test and implement.

[0]: https://github.com/samtools/htslib
[1]: https://github.com/samtools/samtools