### PR TITLE
fix build break with YEPPP

### DIFF
--- a/HisMaker.cpp
+++ b/HisMaker.cpp
@@ -1905,9 +1905,9 @@ void calcLevelsInner(const double* lev_rd,const double *inv_rd,
 	}
       }
 #ifdef USE_YEPPP
-      yepMath_Exp_V64f_V64f(window + left - bb + win, window_next + left - bb + win, right - left + 1);
+      yepMath_Exp_V64f_V64f(window_rd + left - bb + win, window_aib + left - bb + win, right - left + 1);
       double dot_product = 0;
-      yepCore_DotProduct_V64fV64f_S64f(exps + left - bb + win, window_next + left - bb + win, &dot_product, right - left + 1);
+      yepCore_DotProduct_V64fV64f_S64f(exps + left - bb + win, window_aib + left - bb + win, &dot_product, right - left + 1);
       grad_b_b += dot_product;
 #else
       for (int ii = left; ii <= right; ii++) {


### PR DESCRIPTION
```
HisMaker.cpp: In function ‘void calcLevelsInner(const double*, const double*, const bool*, int, int, double*, const double*, const double*)’:
HisMaker.cpp:1907:29: error: ‘window’ was not declared in this scope
       yepMath_Exp_V64f_V64f(window + left - bb + win, window_next + left - bb + win, right - left + 1);
                             ^~~~~~
HisMaker.cpp:1907:29: note: suggested alternative: ‘window_rd’
       yepMath_Exp_V64f_V64f(window + left - bb + win, window_next + left - bb + win, right - left + 1);
                             ^~~~~~
                             window_rd
HisMaker.cpp:1907:55: error: ‘window_next’ was not declared in this scope
       yepMath_Exp_V64f_V64f(window + left - bb + win, window_next + left - bb + win, right - left + 1);
                                                       ^~~~~~~~~~~
HisMaker.cpp:1907:55: note: suggested alternative: ‘window_aib’
       yepMath_Exp_V64f_V64f(window + left - bb + win, window_next + left - bb + win, right - left + 1);
                                                       ^~~~~~~~~~~
                                                       window_aib
Makefile:63: recipe for target 'obj/HisMaker.o' failed
make: *** [obj/HisMaker.o] Error 1
```