### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+Dockerfile
+ExampleData/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+FROM ubuntu:18.04
+
+RUN apt update && apt install -y --no-install-recommends \
+  ca-certificates \
+  g++ \
+  libbz2-dev \
+  libcurl3-dev \
+  libfreetype6-dev \
+  liblzma-dev \
+  libncurses5-dev \
+  libreadline-dev \
+  libpython2.7 \
+  libz-dev \
+  make \
+  python-matplotlib \
+  python-scipy \
+  python-tk \
+  curl \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN curl https://root.cern/download/root_v6.18.04.Linux-ubuntu18-x86_64-gcc7.4.tar.gz | \
+ tar -C /opt -xzf -
+
+ENV PYTHONPATH=/opt/root/lib
+
+RUN echo '/opt/root/lib' > /etc/ld.so.conf.d/root.conf \
+ && ldconfig
+
+RUN curl -L https://github.com/samtools/samtools/releases/download/1.9/samtools-1.9.tar.bz2 | \
+ tar -C /tmp -xjf - \
+ && cd /tmp/samtools-* \
+ && make \
+ && (cd htslib-* && make mostlyclean) \
+ && make mostlyclean \
+ && find /tmp -name test -type d -exec rm -rf {} +
+
+COPY ./ /tmp/CNVnator
+
+RUN cd /tmp/CNVnator \
+ && ln -s /tmp/samtools-* samtools \
+ && ROOTSYS=/opt/root make \
+ && mv cnvnator *.py *.pl /usr/local/bin \
+ && mv pytools /usr/local/lib/python*/dist-packages \
+ && cd - \
+ && rm -rf /tmp/*


### PR DESCRIPTION
A colleague faced challenges installing CNVnator in the software environment of our HPC cluster, so I built a Docker image using this Dockerfile, and then used [docker2singularity](https://github.com/singularityhub/docker2singularity) to export a [Singularity](https://github.com/sylabs/singularity) image for use on the HPC cluster. Given the specific dependencies and build process required by CNVnator, it could be useful to provide such an "official" Docker image containing a known-working installation, or at least a Dockerfile in the git repo for building such an image.

While the resulting Docker image has not been extensively tested (my colleague is currently evaluating the Singularity image), it should be a good starting point (perhaps with some instructions added to the README.md, which I'd be happy to contribute if requested).