### PR TITLE
Broaden wildcard for the htslib subdirectory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ endif
 
 SAMDIR = samtools
 SAMLIB = $(SAMDIR)/libbam.a
-HTSDIR = $(wildcard $(SAMDIR)/htslib-*)
+HTSDIR = $(wildcard $(SAMDIR)/htslib*)
 HTSDIRI = $(HTSDIR)/htslib
 ifneq ($(HTSDIR),)
         SAMLIB += $(HTSDIR)/libhts.a

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ $ ./plotcircular.py file.root
 
 You must install [ROOT package](http://root.cern.ch) and set up `$ROOTSYS` variable (see ROOT documentation [here](https://root.cern.ch/root/html534/guides/users-guide/GettingStarted.html)).
 
-Also, a link to the samtools binary should be present in your CNVnator directory.
+Also, a link to the samtools binary should be present in your CNVnator directory together with compiled `libhts.a` HTSlib library in a `htslib*` subdirectory.
 
 If compilation is not completed but the file libbam.a has been created, you can continue.
 


### PR DESCRIPTION
With currently used `htslib-*` wildcard content of directories like
`htslib` or `htslibX` will be skipped altogether and linking will fail
due to the `libhts.a` library being missing.

This change makes the wildcard broader.